### PR TITLE
Update formula dependency

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -51,6 +51,7 @@ brews:
   folder: Formula
   dependencies:
     - awscli
+    - disneystreaming/aws-session-manager-plugin
 
 dockers:
   - binaries:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -51,7 +51,7 @@ brews:
   folder: Formula
   dependencies:
     - awscli
-    - disneystreaming/aws-session-manager-plugin
+    - disneystreaming/tap/aws-session-manager-plugin
 
 dockers:
   - binaries:


### PR DESCRIPTION
Need to merge disneystreaming/homebrew-tap#1 first

The next release of ssm-helpers will auto-generate the tap formula and overwrite the changes there.