### PR TITLE
Add -l shorthand for limit

### DIFF
--- a/cmd/ssm-run/main.go
+++ b/cmd/ssm-run/main.go
@@ -90,6 +90,7 @@ func main() {
 
 	// Flag to set a limit to the number of instances returned by the SSM/EC2 API query
 	flag.IntVar(&limitFlag, "limit", 0, "Set a limit for the number of instance results returned per profile/region combination (0 = no limit)")
+	flag.IntVar(&limitFlag, "l", "--limit (shorthand)")
 
 	flag.Parse()
 

--- a/cmd/ssm-session/main.go
+++ b/cmd/ssm-session/main.go
@@ -95,6 +95,7 @@ func main() {
 
 	// Flag to set a limit to the number of instances returned by the SSM/EC2 API query
 	flag.IntVar(&limitFlag, "limit", 20, "Set a limit for the number of instance results returned per profile/region combination.")
+	flag.IntVar(&limitFlag, "l", "--limit (shorthand)")
 
 	flag.Parse()
 


### PR DESCRIPTION
I seriously try to do `-l` almost every time I run ssm-session. I think it might be worth making it shorthand.

Only problem is if we want to make a short flag for `--log-limit`

WDYT?