### PR TITLE
Add -version flag

### DIFF
--- a/cmd/ssm-run/main.go
+++ b/cmd/ssm-run/main.go
@@ -30,6 +30,9 @@ var allProfilesFlag bool
 var verboseFlag int
 var dryRunFlag bool
 var limitFlag int
+var versionFlag bool
+var version = "devel"
+var commit = "notpassed"
 
 func main() {
 	// Get the number of cores available for parallelization
@@ -91,7 +94,15 @@ func main() {
 	// Flag to set a limit to the number of instances returned by the SSM/EC2 API query
 	flag.IntVar(&limitFlag, "limit", 0, "Set a limit for the number of instance results returned per profile/region combination (0 = no limit)")
 
+	// Flag to show the version number
+	flag.BoolVar(&versionFlag, "version", false, "Show version and quit")
+
 	flag.Parse()
+
+	if versionFlag {
+		fmt.Printf("Version: %s\tGit Commit Hash: %s\n", version, commit)
+		os.Exit(0)
+	}
 
 	if verboseFlag == 0 && dryRunFlag {
 		verboseFlag = 1

--- a/cmd/ssm-session/main.go
+++ b/cmd/ssm-session/main.go
@@ -36,6 +36,9 @@ var dryRunFlag bool
 var sessionName string
 var limitFlag int
 var totalInstances int
+var versionFlag bool
+var version = "devel"
+var commit = "notpassed"
 
 func main() {
 	// Get the number of cores available for parallelization
@@ -96,7 +99,15 @@ func main() {
 	// Flag to set a limit to the number of instances returned by the SSM/EC2 API query
 	flag.IntVar(&limitFlag, "limit", 20, "Set a limit for the number of instance results returned per profile/region combination.")
 
+	// Flag to show the version number
+	flag.BoolVar(&versionFlag, "version", false, "Show version and quit")
+
 	flag.Parse()
+
+	if versionFlag {
+		fmt.Printf("Version: %s\tGit Commit Hash: %s\n", version, commit)
+		os.Exit(0)
+	}
 
 	if verboseFlag == 3 {
 		log.SetLevel(log.DebugLevel)


### PR DESCRIPTION
I'm open to suggestions on defaults for version and commit.
goreleaser will automatically add flags
```
-s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser
```

We can customize it if we want.

fixes #7