### PR TITLE
Fix shared limit flag

### DIFF
--- a/cmd/ssm-run/main.go
+++ b/cmd/ssm-run/main.go
@@ -227,11 +227,12 @@ func main() {
 				}
 			}
 
-			if limitFlag == 0 || limitFlag > len(info) {
-				limitFlag = len(info)
+			limit := len(info)
+			if limitFlag != 0 && limitFlag < limit {
+				limit = limitFlag
 			}
 
-			err = ssmhelpers.RunInvocations(sess, svc, info[:limitFlag], params, dryRunFlag, completedInvocations)
+			err = ssmhelpers.RunInvocations(sess, svc, info[:limit], params, dryRunFlag, completedInvocations)
 			if err != nil {
 				log.Error(err)
 			}


### PR DESCRIPTION
If one is using multiple accounts the limit flag was shared between the threads.
This lead to a race condition that limited the amount processed instances.

For example:
Imagine you have two accounts `acc-1` and `acc-2` and you would like to execute a command on all the instances with a given set of labels.

```
ssm-run -r eu-central-1 -l 0 -f Environment=... -p acc-1,acc-2
```

In acc-1 it will match 3 instances whereas acc-2 will match 5. Even without setting the limit flag it will probably only process 3 instances of acc-2, because the limit flag is a shared variable that was mutated by both threads.