### PR TITLE
Prefix SliceToTargets keys with "tag:"

### DIFF
--- a/util/common.go
+++ b/util/common.go
@@ -37,7 +37,7 @@ func SliceToTargets(kvslice []string) (targets []*ssm.Target) {
 	for i := 0; i < len(kvslice); i++ {
 		elements = strings.Split(kvslice[i], "=")
 		targets = append(targets, &ssm.Target{
-			Key:    aws.String(elements[0]),
+			Key:    aws.String("tag:" + elements[0]),
 			Values: aws.StringSlice([]string{elements[1]}),
 		})
 	}


### PR DESCRIPTION
This one is up in the air. It'll give us a more consistent UX between `run` and `session`, but would take away the ability to target things like Resource Groups with `run`. Open to feedback. 