### PR TITLE
Testing workflow and paginated test fixes

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,65 @@
+# Update the VARIANT arg in devcontainer.json to pick an Go version
+ARG VARIANT=1
+FROM golang:${VARIANT}
+
+# Options for setup script
+ARG INSTALL_ZSH="true"
+ARG UPGRADE_PACKAGES="false"
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.
+COPY library-scripts/*.sh /tmp/library-scripts/
+RUN apt-get update \
+    && /bin/bash /tmp/library-scripts/common-debian.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" \
+    && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
+
+# Install Go tools
+ARG GO_TOOLS_WITH_MODULES="\
+    golang.org/x/tools/gopls \
+    honnef.co/go/tools/... \
+    golang.org/x/tools/cmd/gorename \
+    golang.org/x/tools/cmd/goimports \
+    golang.org/x/tools/cmd/guru \
+    golang.org/x/lint/golint \
+    github.com/mdempsky/gocode \
+    github.com/cweill/gotests/... \
+    github.com/haya14busa/goplay/cmd/goplay \
+    github.com/sqs/goreturns \
+    github.com/josharian/impl \
+    github.com/davidrjenni/reftools/cmd/fillstruct \
+    github.com/uudashr/gopkgs/v2/cmd/gopkgs \
+    github.com/ramya-rao-a/go-outline \
+    github.com/acroca/go-symbols \
+    github.com/godoctor/godoctor \
+    github.com/rogpeppe/godef \
+    github.com/zmb3/gogetdoc \
+    github.com/fatih/gomodifytags \
+    github.com/mgechev/revive \
+    github.com/go-delve/delve/cmd/dlv"
+RUN mkdir -p /tmp/gotools \
+    && cd /tmp/gotools \
+    && export GOPATH=/tmp/gotools \
+    # Go tools w/module support
+    && export GO111MODULE=on \
+    && (echo "${GO_TOOLS_WITH_MODULES}" | xargs -n 1 go get -x )2>&1 \
+    # gocode-gomod
+    && export GO111MODULE=auto \
+    && go get -x -d github.com/stamblerre/gocode 2>&1 \
+    && go build -o gocode-gomod github.com/stamblerre/gocode \
+    # golangci-lint
+    && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/local/bin 2>&1 \
+    # Move Go tools into path and clean up
+    && mv /tmp/gotools/bin/* /usr/local/bin/ \
+    && mv gocode-gomod /usr/local/bin/ \
+    && rm -rf /tmp/gotools
+
+ENV GO111MODULE=auto
+
+# [Optional] Uncomment the next line to use go get to install anything else you need
+# RUN go get -x <your-dependency-or-tool>
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,28 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.134.1/containers/go
+{
+	"name": "Go",
+	"build": {
+		"dockerfile": "Dockerfile",
+		// Update the VARIANT arg to pick a version of Go
+		"args": {
+			"VARIANT": "1.13"
+		}
+	},
+	"runArgs": [
+		"--cap-add=SYS_PTRACE",
+		"--security-opt",
+		"seccomp=unconfined"
+	],
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		"terminal.integrated.shell.linux": "/bin/bash",
+		"go.useGoProxyToCheckForToolUpdates": false,
+		"go.gopath": "/go"
+	},
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"golang.Go"
+	],
+	"remoteUser": "vscode"
+}

--- a/.devcontainer/library-scripts/common-debian.sh
+++ b/.devcontainer/library-scripts/common-debian.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+# Syntax: ./common-debian.sh [install zsh flag] [username] [user UID] [user GID] [upgrade packages flag]
+
+INSTALL_ZSH=${1:-"true"}
+USERNAME=${2:-"vscode"}
+USER_UID=${3:-1000}
+USER_GID=${4:-1000}
+UPGRADE_PACKAGES=${5:-"true"}
+
+set -e
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+# Treat a user name of "none" as root
+if [ "${USERNAME}" = "none" ] || [ "${USERNAME}" = "root" ]; then
+    USERNAME=root
+    USER_UID=0
+    USER_GID=0
+fi
+
+# Load markers to see which steps have already run
+MARKER_FILE="/usr/local/etc/vscode-dev-containers/common"
+if [ -f "${MARKER_FILE}" ]; then
+    echo "Marker file found:"
+    cat "${MARKER_FILE}"
+    source "${MARKER_FILE}"
+fi
+
+# Ensure apt is in non-interactive to avoid prompts
+export DEBIAN_FRONTEND=noninteractive
+
+# Function to call apt-get if needed
+apt-get-update-if-needed()
+{
+    if [ ! -d "/var/lib/apt/lists" ] || [ "$(ls /var/lib/apt/lists/ | wc -l)" = "0" ]; then
+        echo "Running apt-get update..."
+        apt-get update
+    else
+        echo "Skipping apt-get update."
+    fi
+}
+
+# Run install apt-utils to avoid debconf warning then verify presence of other common developer tools and dependencies
+if [ "${PACKAGES_ALREADY_INSTALLED}" != "true" ]; then
+    apt-get-update-if-needed
+
+    PACKAGE_LIST="apt-utils \
+        git \
+        openssh-client \
+        less \
+        iproute2 \
+        procps \
+        curl \
+        wget \
+        unzip \
+        nano \
+        jq \
+        lsb-release \
+        ca-certificates \
+        apt-transport-https \
+        dialog \
+        gnupg2 \
+        libc6 \
+        libgcc1 \
+        libgssapi-krb5-2 \
+        libicu[0-9][0-9] \
+        liblttng-ust0 \
+        libstdc++6 \
+        zlib1g \
+        locales \
+        sudo"
+
+    # Install libssl1.1 if available
+    if [[ ! -z $(apt-cache --names-only search ^libssl1.1$) ]]; then
+        PACKAGE_LIST="${PACKAGE_LIST}       libssl1.1"
+    fi
+    
+    # Install appropriate version of libssl1.0.x if available
+    LIBSSL=$(dpkg-query -f '${db:Status-Abbrev}\t${binary:Package}\n' -W 'libssl1\.0\.?' 2>&1 || echo '')
+    if [ "$(echo "$LIBSSL" | grep -o 'libssl1\.0\.[0-9]:' | uniq | sort | wc -l)" -eq 0 ]; then
+        if [[ ! -z $(apt-cache --names-only search ^libssl1.0.2$) ]]; then
+            # Debian 9
+            PACKAGE_LIST="${PACKAGE_LIST}       libssl1.0.2"
+        elif [[ ! -z $(apt-cache --names-only search ^libssl1.0.0$) ]]; then
+            # Ubuntu 18.04, 16.04, earlier
+            PACKAGE_LIST="${PACKAGE_LIST}       libssl1.0.0"
+        fi
+    fi
+
+    echo "Packages to verify are installed: ${PACKAGE_LIST}"
+    apt-get -y install --no-install-recommends ${PACKAGE_LIST} 2> >( grep -v 'debconf: delaying package configuration, since apt-utils is not installed' >&2 )
+        
+    PACKAGES_ALREADY_INSTALLED="true"
+fi
+
+# Get to latest versions of all packages
+if [ "${UPGRADE_PACKAGES}" = "true" ]; then
+    apt-get-update-if-needed
+    apt-get -y upgrade --no-install-recommends
+    apt-get autoremove -y
+fi
+
+# Ensure at least the en_US.UTF-8 UTF-8 locale is available.
+# Common need for both applications and things like the agnoster ZSH theme.
+if [ "${LOCALE_ALREADY_SET}" != "true" ]; then
+    echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen 
+    locale-gen
+    LOCALE_ALREADY_SET="true"
+fi
+
+# Create or update a non-root user to match UID/GID - see https://aka.ms/vscode-remote/containers/non-root-user.
+if id -u $USERNAME > /dev/null 2>&1; then
+    # User exists, update if needed
+    if [ "$USER_GID" != "$(id -G $USERNAME)" ]; then 
+        groupmod --gid $USER_GID $USERNAME 
+        usermod --gid $USER_GID $USERNAME
+    fi
+    if [ "$USER_UID" != "$(id -u $USERNAME)" ]; then 
+        usermod --uid $USER_UID $USERNAME
+    fi
+else
+    # Create user
+    groupadd --gid $USER_GID $USERNAME
+    useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME
+fi
+
+# Add add sudo support for non-root user
+if [ "${EXISTING_NON_ROOT_USER}" != "${USERNAME}" ]; then
+    echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME
+    chmod 0440 /etc/sudoers.d/$USERNAME
+    EXISTING_NON_ROOT_USER="${USERNAME}"
+fi
+
+# Ensure ~/.local/bin is in the PATH for root and non-root users for bash. (zsh is later)
+if [ "${DOT_LOCAL_ALREADY_ADDED}" != "true" ]; then
+    echo "export PATH=\$PATH:\$HOME/.local/bin" | tee -a /root/.bashrc >> /home/$USERNAME/.bashrc 
+    chown $USER_UID:$USER_GID /home/$USERNAME/.bashrc
+    DOT_LOCAL_ALREADY_ADDED="true"
+fi
+
+# Optionally install and configure zsh
+if [ "${INSTALL_ZSH}" = "true" ] && [ ! -d "/root/.oh-my-zsh" ] && [ "${ZSH_ALREADY_INSTALLED}" != "true" ]; then
+    apt-get-update-if-needed
+    apt-get install -y zsh
+    curl -fsSLo- https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh | bash 2>&1
+    echo "export PATH=\$PATH:\$HOME/.local/bin" >> /root/.zshrc
+    if [ "${USERNAME}" != "root" ]; then
+        cp -fR /root/.oh-my-zsh /home/$USERNAME
+        cp -f /root/.zshrc /home/$USERNAME
+        sed -i -e "s/\/root\/.oh-my-zsh/\/home\/$USERNAME\/.oh-my-zsh/g" /home/$USERNAME/.zshrc
+        chown -R $USER_UID:$USER_GID /home/$USERNAME/.oh-my-zsh /home/$USERNAME/.zshrc
+    fi
+    ZSH_ALREADY_INSTALLED="true"
+fi
+
+# Write marker file
+mkdir -p "$(dirname "${MARKER_FILE}")"
+echo -e "\
+    PACKAGES_ALREADY_INSTALLED=${PACKAGES_ALREADY_INSTALLED}\n\
+    LOCALE_ALREADY_SET=${LOCALE_ALREADY_SET}\n\
+    EXISTING_NON_ROOT_USER=${EXISTING_NON_ROOT_USER}\n\
+    DOT_LOCAL_ALREADY_ADDED=${DOT_LOCAL_ALREADY_ADDED}\n\
+    ZSH_ALREADY_INSTALLED=${ZSH_ALREADY_INSTALLED}" > "${MARKER_FILE}"

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -16,7 +16,7 @@ jobs:
           go-version: 1.13.x
       
       - name: Formatting (goimports)
-        run: make format.check
+        run: PATH=${PATH}:`go env GOPATH`/bin make format.check
 
       - name: Testing (gotest)
         run: make test

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -16,7 +16,7 @@ jobs:
           go-version: 1.13.x
       
       - name: Formatting (goimports)
-        run: make format
+        run: make format.check
 
       - name: Testing (gotest)
         run: make test

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -1,0 +1,22 @@
+name: Code Quality (gofmt, gotest
+on: [pull_request, create]
+
+jobs:
+  build:
+    if: github.event_name == 'pull_request'
+    name: Code Quality (gofmt, gotest)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Set up Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.13.x
+      
+      - name: Formatting (goimports)
+        run: make format
+
+      - name: Testing (gotest)
+        run: make test

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -1,4 +1,4 @@
-name: Code Quality (gofmt, gotest
+name: Code Quality (gofmt, gotest)
 on: [pull_request, create]
 
 jobs:

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -95,7 +95,6 @@ func runCommand(cmd *cobra.Command, args []string) {
 		MaxErrors:      aws.String(maxErrors),
 	}
 
-
 	wg, output := sync.WaitGroup{}, invocation.ResultSafe{}
 
 	// Set up our AWS session for each permutation of profile + region and iterate over them

--- a/ec2/helpers.go
+++ b/ec2/helpers.go
@@ -13,7 +13,7 @@ func getEC2InstanceInfo(client ec2iface.EC2API, instances []*string) (output []*
 		InstanceIds: instances,
 	}
 
-	describeInstacesPager := func(page *ec2.DescribeInstancesOutput, lastPage bool) bool {
+	describeInstancesPager := func(page *ec2.DescribeInstancesOutput, lastPage bool) bool {
 		for _, reservation := range page.Reservations {
 			output = append(output, reservation.Instances...)
 		}
@@ -29,7 +29,7 @@ func getEC2InstanceInfo(client ec2iface.EC2API, instances []*string) (output []*
 	}
 
 	// Fetch all the instances described
-	if err = client.DescribeInstancesPages(diInput, describeInstacesPager); err != nil {
+	if err = client.DescribeInstancesPages(diInput, describeInstancesPager); err != nil {
 		return nil, fmt.Errorf("Could not describe EC2 instances\n%v", err)
 	}
 

--- a/ec2/helpers.go
+++ b/ec2/helpers.go
@@ -18,14 +18,8 @@ func getEC2InstanceInfo(client ec2iface.EC2API, instances []*string) (output []*
 			output = append(output, reservation.Instances...)
 		}
 
-		// Last page, break out
-		if page.NextToken == nil {
-			return false
-		}
-
-		// If not, set the token in order to fetch the next page
-		diInput.SetNextToken(*page.NextToken)
-		return true
+		// If it's not the last page, continue
+		return !lastPage
 	}
 
 	// Fetch all the instances described
@@ -38,7 +32,6 @@ func getEC2InstanceInfo(client ec2iface.EC2API, instances []*string) (output []*
 
 // GetEC2InstanceTags accepts any number of instance strings and returns a populated InstanceTags{} object for each instance
 func GetEC2InstanceTags(client ec2iface.EC2API, instances []*string) (ec2Tags map[string]Tags, err error) {
-
 	instanceInfo, err := getEC2InstanceInfo(client, instances)
 	if err != nil {
 		return nil, fmt.Errorf("Error when trying to retrieve EC2 instance tags\n%v", err)

--- a/ec2/helpers_test.go
+++ b/ec2/helpers_test.go
@@ -16,9 +16,14 @@ func TestGetEC2InstanceTags(t *testing.T) {
 	t.Run("", func(t *testing.T) {
 		tags, err := GetEC2InstanceTags(mockSvc, aws.StringSlice([]string{"i-123", "i-456", "i-789"}))
 
+		keys := make([]string, 0, 3)
+		for k, _ := range tags {
+			keys = append(keys, k)
+		}
+
 		assert.NoError(err)
 		assert.Lenf(tags, 3, "Incorrect number of tag slices returned, got %d, expected 3", len(tags))
-		assert.Contains(tags, []string{"i-123", "i-456", "i-789"}, "Incorrect instance ID returned in tag slice\n%v", tags)
+		assert.Equal(keys, []string{"i-123", "i-456", "i-789"}, "Incorrect instance ID returned in tag slice\n%v", tags)
 		assert.Equal(tags["i-123"]["env"], "dev", "Incorrect tag values returned for instance i-123, got , expected env:dev and id_foo:321")
 
 	})

--- a/ec2/helpers_test.go
+++ b/ec2/helpers_test.go
@@ -17,13 +17,13 @@ func TestGetEC2InstanceTags(t *testing.T) {
 		tags, err := GetEC2InstanceTags(mockSvc, aws.StringSlice([]string{"i-123", "i-456", "i-789"}))
 
 		keys := make([]string, 0, 3)
-		for k, _ := range tags {
+		for k := range tags {
 			keys = append(keys, k)
 		}
 
 		assert.NoError(err)
 		assert.Lenf(tags, 3, "Incorrect number of tag slices returned, got %d, expected 3", len(tags))
-		assert.Equal(keys, []string{"i-123", "i-456", "i-789"}, "Incorrect instance ID returned in tag slice\n%v", tags)
+		assert.ElementsMatch(keys, []string{"i-123", "i-456", "i-789"}, "Incorrect instance ID returned in tag slice\n%v", tags)
 		assert.Equal(tags["i-123"]["env"], "dev", "Incorrect tag values returned for instance i-123, got , expected env:dev and id_foo:321")
 
 	})

--- a/go.sum
+++ b/go.sum
@@ -131,6 +131,7 @@ github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/ssm/instance/fetch.go
+++ b/ssm/instance/fetch.go
@@ -16,14 +16,8 @@ func GetSessionInstances(client ssmiface.SSMAPI, diiInput *ssm.DescribeInstanceI
 				output = append(output, instance)
 			}
 
-			// Last page, break out
-			if page.NextToken == nil {
-				return false
-			}
-
-			// If not, set the token in order to fetch the next page
-			diiInput.SetNextToken(*page.NextToken)
-			return true
+			// If it's not the last page, continue
+			return !lastPage
 		}); err != nil {
 		return nil, fmt.Errorf("Could not retrieve SSM instance info\n%v", err)
 	}

--- a/ssm/instance/fetch_test.go
+++ b/ssm/instance/fetch_test.go
@@ -9,7 +9,7 @@ import (
 	mocks "github.com/disneystreaming/ssm-helpers/testing"
 )
 
-func TestGGetSessionInstances(t *testing.T) {
+func TestGetSessionInstances(t *testing.T) {
 	assert := assert.New(t)
 
 	// Set up our mock session and input object

--- a/ssm/instance/fetch_test.go
+++ b/ssm/instance/fetch_test.go
@@ -3,6 +3,7 @@ package instance
 import (
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/stretchr/testify/assert"
 
@@ -16,7 +17,22 @@ func TestGetSessionInstances(t *testing.T) {
 	mockSvc := &mocks.MockSSMClient{}
 
 	t.Run("latest agent version filter", func(t *testing.T) {
-		ssmInput := &ssm.DescribeInstanceInformationInput{}
+		ssmInput := &ssm.DescribeInstanceInformationInput{
+			Filters: []*ssm.InstanceInformationStringFilter{
+				{
+					Key:    aws.String("PingStatus"),
+					Values: aws.StringSlice([]string{"Online"}),
+				},
+				{
+					Key:    aws.String("PlatformType"),
+					Values: aws.StringSlice([]string{"Linux"}),
+				},
+				{
+					Key:    aws.String("IsLatestVersion"),
+					Values: aws.StringSlice([]string{"true"}),
+				},
+			},
+		}
 		instances, err := GetSessionInstances(mockSvc, ssmInput)
 
 		// Function should filter out any instances that are offline or not running Linux or do not have the latest agent version
@@ -25,7 +41,18 @@ func TestGetSessionInstances(t *testing.T) {
 	})
 
 	t.Run("standard instance filters", func(t *testing.T) {
-		ssmInput := &ssm.DescribeInstanceInformationInput{}
+		ssmInput := &ssm.DescribeInstanceInformationInput{
+			Filters: []*ssm.InstanceInformationStringFilter{
+				{
+					Key:    aws.String("PingStatus"),
+					Values: aws.StringSlice([]string{"Online"}),
+				},
+				{
+					Key:    aws.String("PlatformType"),
+					Values: aws.StringSlice([]string{"Linux"}),
+				},
+			},
+		}
 		instances, err := GetSessionInstances(mockSvc, ssmInput)
 
 		// Function should filter out any instances that are offline or not running Linux

--- a/ssm/invocation/runner_test.go
+++ b/ssm/invocation/runner_test.go
@@ -5,8 +5,9 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ssm"
-	mocks "github.com/disneystreaming/ssm-helpers/testing"
 	"github.com/stretchr/testify/assert"
+
+	mocks "github.com/disneystreaming/ssm-helpers/testing"
 )
 
 func TestGetResult(t *testing.T) {

--- a/testing/ec2_mocks.go
+++ b/testing/ec2_mocks.go
@@ -77,11 +77,11 @@ func (m *MockEC2Client) DescribeInstancesPages(input *ec2.DescribeInstancesInput
 		// Just keep chugging unless we are at the end of the page.
 		if output.NextToken == nil || !continueIterating {
 			break
-		} else {
-			// continue until full list is consumed
-			input.SetNextToken(*output.NextToken)
-			output, err = m.DescribeInstances(input)
 		}
+
+		// continue until full list is consumed
+		input.SetNextToken(*output.NextToken)
+		output, err = m.DescribeInstances(input)
 	}
 
 	return err

--- a/testing/ec2_mocks.go
+++ b/testing/ec2_mocks.go
@@ -64,3 +64,26 @@ func (m *MockEC2Client) DescribeInstances(input *ec2.DescribeInstancesInput) (ou
 
 	return output, nil
 }
+
+func (m *MockEC2Client) DescribeInstancesPages(input *ec2.DescribeInstancesInput, fn func(*ec2.DescribeInstancesOutput, bool) bool) error {
+	var err error = nil
+	var continueIterating bool = true
+
+	// Grab initial case and start looping
+	output, err := m.DescribeInstances(input)
+	for err == nil && continueIterating {
+		continueIterating = fn(output, (output.NextToken == nil))
+
+		// Just keep chugging unless we are at the end of the page.
+		if output.NextToken == nil || !continueIterating {
+			break
+		} else {
+			// continue until full list is consumed
+			input.SetNextToken(*output.NextToken)
+			output, err = m.DescribeInstances(input)
+		}
+
+	}
+
+	return err
+}

--- a/testing/ec2_mocks.go
+++ b/testing/ec2_mocks.go
@@ -82,7 +82,6 @@ func (m *MockEC2Client) DescribeInstancesPages(input *ec2.DescribeInstancesInput
 			input.SetNextToken(*output.NextToken)
 			output, err = m.DescribeInstances(input)
 		}
-
 	}
 
 	return err

--- a/testing/ssm_mocks.go
+++ b/testing/ssm_mocks.go
@@ -66,16 +66,16 @@ func (m *MockSSMClient) GetCommandInvocation(input *ssm.GetCommandInvocationInpu
 		status = "Pending"
 	case "bad-id":
 		return nil, awserr.New("InvalidCommandId", "InvalidCommandId", nil)
-		}
-
-		output = &ssm.GetCommandInvocationOutput{
-			InstanceId:    input.InstanceId,
-			CommandId:     input.CommandId,
-		StatusDetails: aws.String(status),
-		}
-
-		return output, nil
 	}
+
+	output = &ssm.GetCommandInvocationOutput{
+		InstanceId:    input.InstanceId,
+		CommandId:     input.CommandId,
+		StatusDetails: aws.String(status),
+	}
+
+	return output, nil
+}
 
 func (m *MockSSMClient) SendCommand(input *ssm.SendCommandInput) (output *ssm.SendCommandOutput, err error) {
 	if len(input.InstanceIds) > 0 && len(input.Targets) > 0 {

--- a/testing/ssm_mocks.go
+++ b/testing/ssm_mocks.go
@@ -159,3 +159,9 @@ func (m *MockSSMClient) DescribeInstanceInformation(input *ssm.DescribeInstanceI
 	return output, err
 
 }
+
+func (m *MockSSMClient) DescribeInstanceInformationPages(input *ssm.DescribeInstanceInformationInput, fn func(*ssm.DescribeInstanceInformationOutput, bool) bool) (err error) {
+
+	// Mock our response from the SSM API
+	return nil
+}

--- a/testing/ssm_mocks.go
+++ b/testing/ssm_mocks.go
@@ -172,11 +172,11 @@ func (m *MockSSMClient) DescribeInstanceInformationPages(input *ssm.DescribeInst
 		// Just keep chugging unless we are at the end of the page.
 		if output.NextToken == nil || !continueIterating {
 			break
-		} else {
-			// continue until full list is consumed
-			input.SetNextToken(*output.NextToken)
-			output, err = m.DescribeInstanceInformation(input)
 		}
+
+		// continue until full list is consumed
+		input.SetNextToken(*output.NextToken)
+		output, err = m.DescribeInstanceInformation(input)
 
 	}
 


### PR DESCRIPTION
# General
This PR includes test fixes, additional developer tooling and a new workflow.

## Test Fixes
This PR implements a new method on the ssm and ec2 mocks respectively to cover paginator calls. After the included changes tests are passing again.

These changes are:
- Implementing `DescribeInstanceInformationPages` method in the ssm API mocks
- Implementing `DescribeInstancesPages` method in the ec2 API mocks

## New Workflow
This PR also introduces a new `code_quality` workflow that handles running `make format` and `make test` on PR creation.

## Other Changes
In addition to the above fixes, this PR includes a few additional small changes
- ran a `make format` to format branch
- small cleanups to the pagination callbacks
- addition of a devcontainer for VS Code users
  - please let me know if this is a problem and I will happily remove it or move to a new PR.