### PR TITLE
Validate number of SSM target filters specified

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -151,6 +151,10 @@ func validateSessionFlags(cmd *cobra.Command, instanceList []string, filterList 
 		return cmdutil.UsageError(cmd, "The --filter and --instance flags cannot be used simultaneously.")
 	}
 
+	if len(filterList) > 5 {
+		return cmdutil.UsageError(cmd, "A maximum of 5 tag filters can be specified at a time.")
+	}
+
 	return nil
 }
 
@@ -162,6 +166,10 @@ func validateRunFlags(cmd *cobra.Command, instanceList []string, commandList []s
 
 	if len(instanceList) == 0 && len(filterList) == 0 {
 		return cmdutil.UsageError(cmd, "You must supply target arguments using either the --filter or --instance flags.")
+	}
+
+	if len(filterList) > 5 {
+		return cmdutil.UsageError(cmd, "A maximum of 5 tag filters can be specified at a time.")
 	}
 
 	if len(instanceList) > 50 {

--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -326,6 +326,12 @@ func Test_validateRunFlags(t *testing.T) {
 		assert.Error(err)
 	})
 
+	t.Run("specify more than 5 filters", func(t *testing.T) {
+		targetList := make([]*ssm.Target, 6)
+		err := validateRunFlags(cmd, nil, []string{"hostname"}, targetList)
+		assert.Error(err)
+	})
+
 	t.Run("no instances or filters specified", func(t *testing.T) {
 		err := validateRunFlags(cmd, nil, []string{"hostname"}, nil)
 		assert.Error(err)
@@ -362,6 +368,19 @@ func Test_validateSessionFlags(t *testing.T) {
 			"foo": "bar",
 		}
 		err := validateSessionFlags(cmd, instanceList, filterList)
+		assert.Error(err)
+	})
+
+	t.Run("specify more than 5 filters", func(t *testing.T) {
+		targetList := map[string]string{
+			"1": "a",
+			"2": "b",
+			"3": "c",
+			"4": "d",
+			"5": "e",
+			"6": "f",
+		}
+		err := validateSessionFlags(cmd, nil, targetList)
 		assert.Error(err)
 	})
 


### PR DESCRIPTION
SSM targets only allow a maximum of 5 filters to be passed for a given target. Adding additional targets will lead to a 400 error being returned by SSM.

```
bin/ssm run -f 'tag:a=1,tag:b=2,tag:c=3,tag:d=4,tag:e=5,tag:f=6' -c 'echo foo'
INFO    Command(s) to be executed:
echo foo
ERROR   Error when calling the SendCommand API for account [redacted in [redacted]
ValidationException: 1 validation error detected: Value '[Target(key=tag:a, values=[1]), Target(key=tag:b, values=[2]), Target(key=tag:c, values=[3]), Target(key=tag:d, values=[4]), Target(key=tag:e, values=[5]), Target(key=tag:f, values=[6])]' at 'targets' failed to satisfy constraint: Member must have length less than or equal to 5.
        status code: 400, request id: [redacted]
INFO    Instance ID              Region          Profile         Status
INFO    Execution results: 0 SUCCESS, 0 FAILED
```

This occurs for both `ssm run` and `ssm session`.

This PR adds an additional check for the number of provided filters and tests to verify expected behavior.