### PR TITLE
Add GHCR as a goreleaser target alongside github packages

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,8 +16,6 @@
 	],
 	// Set *default* container specific settings.json values on container create.
 	"settings": {
-		"terminal.integrated.shell.linux": "/bin/bash",
-		"go.useGoProxyToCheckForToolUpdates": false,
 		"go.gopath": "/go"
 	},
 	// Add the IDs of extensions you want installed when the container is created.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,16 @@ jobs:
         uses: actions/setup-go@v1
         with:
           go-version: 1.13.x
-      - name: Docker login
+      - name: Docker login (github packages)
         uses: azure/docker-login@v1
         with:
           login-server: docker.pkg.github.com
+          username: disneystreaming
+          password: ${{ secrets.GO_RELEASER }}
+      - name: Docker login (ghcr)
+        uses: azure/docker-login@v1
+        with:
+          login-server: ghcr.io 
           username: disneystreaming
           password: ${{ secrets.GO_RELEASER }}
       - name: Run GoReleaser

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -54,6 +54,10 @@ dockers:
     - "docker.pkg.github.com/disneystreaming/ssm-helpers/ssm:{{ .Tag }}"
     - "docker.pkg.github.com/disneystreaming/ssm-helpers/ssm:{{ .Major }}"
     - "docker.pkg.github.com/disneystreaming/ssm-helpers/ssm:{{ .Major }}.{{ .Minor }}"
+    - "ghcr.io/disneystreaming/ssm:latest"
+    - "ghcr.io/disneystreaming/ssm:{{ .Tag }}"
+    - "ghcr.io/disneystreaming/ssm:{{ .Major }}"
+    - "ghcr.io/disneystreaming/ssm:{{ .Major }}.{{ .Minor }}"
 
 nfpms:
   - license: MIT


### PR DESCRIPTION
# General
This PR adds the Github Container Registry as an additional target for docker images. This is to:
- Future proof as Github packages will eventually be superseded by the ghcr.
- Support docker image manifest v2

Additional information is covered on the [Migrating to ghcr](https://docs.github.com/en/packages/working-with-a-github-packages-registry/migrating-to-the-container-registry-from-the-docker-registry) link. 

## Other Changes
In addition to the above fixes, this PR includes a small change to remove an explicit shell setting in the devcontainer spec allowing users to pick their preferred shell for the terminal.