### PR TITLE
Add install directive to specify correct homebrew installed binary.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -45,6 +45,7 @@ brews:
     - disneystreaming/tap/aws-session-manager-plugin
   install: |
     bin.install "ssm"
+    bin.install_symlink  bin/"ssm" => "ssm-helpers"
 
 dockers:
   - binaries:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -43,6 +43,8 @@ brews:
   dependencies:
     - awscli
     - disneystreaming/tap/aws-session-manager-plugin
+  install: |
+    bin.install "ssm"
 
 dockers:
   - binaries:


### PR DESCRIPTION
Currently our releases pack the binary `ssm` into each tar archive. 

https://github.com/disneystreaming/homebrew-tap/blob/master/Formula/ssm-helpers.rb#L28-L30

# General
This PR fixes a bug where our homebrew releases currently are attempting to install a `ssm-helpers` binary from our released archive rather than `ssm`. As can be seen in https://github.com/disneystreaming/homebrew-tap/blob/master/Formula/ssm-helpers.rb#L28-L30

This change _WILL_ change the binary, but this is a change that brings it into consistency with all other deployments.

We can either,
- Make the breaking change
- Make the breaking change and symlink `ssm-helpers` to the binary
- Update the tar binary to `ssm-helpers` consistently

I'm happy to modify this PR to any of the above options.
## Other Changes