### PR TITLE
Instance lookup by IP and hostname via private IP addresses on attached NIC

### DIFF
--- a/aws/resolver/resolve.go
+++ b/aws/resolver/resolve.go
@@ -38,7 +38,7 @@ func (hr *HostnameResolver) ResolveToInstanceId(client ec2iface.EC2API) (output 
 	}
 
 	ipFilter := &ec2.Filter{}
-	ipFilter.SetName("network-interface.addresses.private-ip-address").SetValues(ips)
+	ipFilter.SetName("addresses.private-ip-address").SetValues(ips)
 
 	dniInput := &ec2.DescribeNetworkInterfacesInput{}
 	dniInput.SetFilters([]*ec2.Filter{ipFilter})

--- a/aws/resolver/resolve.go
+++ b/aws/resolver/resolve.go
@@ -27,7 +27,7 @@ func NewHostnameResolver(addrs []string) *HostnameResolver {
 func (hr *HostnameResolver) ResolveToInstanceId(client ec2iface.EC2API) (output []string, err error) {
 	ips := make([]*string, 1)
 	for _, addr := range hr.addrs {
-		ip, err := resolveHostnameToFirst(addr)
+		ip, err := resolveToFirst(addr)
 		if err != nil {
 			return nil, fmt.Errorf("unable to resolve hostname to %v to ip", hr.addrs)
 		}
@@ -60,7 +60,7 @@ func (hr *HostnameResolver) ResolveToInstanceId(client ec2iface.EC2API) (output 
 	return output, nil
 }
 
-func resolveHostnameToFirst(addr string) (net.IP, error) {
+func resolveToFirst(addr string) (net.IP, error) {
 	if ip := net.ParseIP(addr); ip != nil {
 		return ip, nil
 	} else if ips, err := net.LookupIP(addr); err == nil {

--- a/aws/resolver/resolve.go
+++ b/aws/resolver/resolve.go
@@ -1,0 +1,73 @@
+package resolver
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+)
+
+// Provides a interface for resolving an instance to a single ec2 instance.
+type InstanceResolver interface {
+	ResolveToInstanceId(client ec2iface.EC2API) ([]string, error)
+}
+
+/// HostnameResolver attempts to resolve a fqdn or IP to a corresponding instance ID.
+type HostnameResolver struct {
+	addrs []string
+}
+
+func NewHostnameResolver(addrs []string) *HostnameResolver {
+	return &HostnameResolver{
+		addrs: addrs,
+	}
+}
+
+func (hr *HostnameResolver) ResolveToInstanceId(client ec2iface.EC2API) (output []string, err error) {
+	ips := make([]*string, 1)
+	for _, addr := range hr.addrs {
+		ip, err := resolveHostnameToFirst(addr)
+		if err != nil {
+			return nil, fmt.Errorf("unable to resolve hostname to %v to ip", hr.addrs)
+		}
+
+		ipString := ip.String()
+		ips = append(ips, &ipString)
+
+	}
+
+	ipFilter := &ec2.Filter{}
+	ipFilter.SetName("network-interface.addresses.private-ip-address").SetValues(ips)
+
+	dniInput := &ec2.DescribeNetworkInterfacesInput{}
+	dniInput.SetFilters([]*ec2.Filter{ipFilter})
+
+	describeNetworkInterfacesPager := func(page *ec2.DescribeNetworkInterfacesOutput, lastPage bool) bool {
+		for _, nic := range page.NetworkInterfaces {
+			output = append(output, *nic.Attachment.InstanceId)
+		}
+
+		// If it's not the last page, continue
+		return !lastPage
+	}
+
+	// Fetch all the instances described
+	if err = client.DescribeNetworkInterfacesPages(dniInput, describeNetworkInterfacesPager); err != nil {
+		return nil, fmt.Errorf("could not describe network interfaces\n%v", err)
+	}
+
+	return output, nil
+}
+
+func resolveHostnameToFirst(addr string) (net.IP, error) {
+	if ip := net.ParseIP(addr); ip != nil {
+		return ip, nil
+	} else if ips, err := net.LookupIP(addr); err == nil {
+		if len(ips[0]) > 0 {
+			return ips[0], nil
+		}
+	}
+
+	return nil, fmt.Errorf("no IP address found for %s", addr)
+}

--- a/aws/resolver/resolver_test.go
+++ b/aws/resolver/resolver_test.go
@@ -50,20 +50,14 @@ func TestHostnameResolver(t *testing.T) {
 	logger.SetOutput(ioutil.Discard)
 
 	t.Run("test passed ip causes a short circuit", func(t *testing.T) {
-		validIp, err := resolveHostnameToFirst(examplePrivateIpAddress)
+		validIp, err := resolveToFirst(examplePrivateIpAddress)
 		assert.Nil(err)
 		assert.NotNil(validIp)
 		assert.EqualValues(validIp, net.ParseIP(examplePrivateIpAddress))
 	})
 
-	t.Run("test invalid ip throws an error", func(t *testing.T) {
-		validIp, err := resolveHostnameToFirst("127.1.4")
-		assert.NotNil(err)
-		assert.Nil(validIp)
-	})
-
 	t.Run("test passed passed hostname resolves to an IP", func(t *testing.T) {
-		validIp, err := resolveHostnameToFirst("example.com")
+		validIp, err := resolveToFirst("example.com")
 		assert.Nil(err)
 		assert.NotNil(validIp)
 	})

--- a/aws/resolver/resolver_test.go
+++ b/aws/resolver/resolver_test.go
@@ -1,0 +1,79 @@
+package resolver
+
+import (
+	"io/ioutil"
+	"net"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockedEC2 struct {
+	ec2iface.EC2API
+	DescribeNetworkInterfacesOutput []*ec2.DescribeNetworkInterfacesOutput
+}
+
+func (c *mockedEC2) DescribeNetworkInterfacesPages(input *ec2.DescribeNetworkInterfacesInput, fn func(*ec2.DescribeNetworkInterfacesOutput, bool) bool) error {
+	totalPages := len(c.DescribeNetworkInterfacesOutput)
+	for i, output := range c.DescribeNetworkInterfacesOutput {
+		isLastPage := (i == (totalPages - 1))
+		if breakLoop := fn(output, isLastPage); breakLoop {
+			break
+		}
+	}
+	return nil
+}
+
+var (
+	exampleInstanceId                             = "i-1234567890abcdef0"
+	examplePrivateIpAddress                       = "127.0.0.1"
+	singleResponseDescribeNetworkInterfacesOutput = ec2.DescribeNetworkInterfacesOutput{
+		NetworkInterfaces: []*ec2.NetworkInterface{
+			{
+				Attachment: &ec2.NetworkInterfaceAttachment{
+					InstanceId: &exampleInstanceId,
+				},
+				PrivateIpAddress: &examplePrivateIpAddress,
+			},
+		},
+		NextToken: nil,
+	}
+)
+
+func TestHostnameResolver(t *testing.T) {
+	assert := assert.New(t)
+
+	logger := logrus.New()
+	logger.SetOutput(ioutil.Discard)
+
+	t.Run("test passed ip causes a short circuit", func(t *testing.T) {
+		validIp, err := resolveHostnameToFirst(examplePrivateIpAddress)
+		assert.Nil(err)
+		assert.NotNil(validIp)
+		assert.EqualValues(validIp, net.ParseIP(examplePrivateIpAddress))
+	})
+
+	t.Run("test invalid ip throws an error", func(t *testing.T) {
+		validIp, err := resolveHostnameToFirst("127.1.4")
+		assert.NotNil(err)
+		assert.Nil(validIp)
+	})
+
+	t.Run("test passed passed hostname resolves to an IP", func(t *testing.T) {
+		validIp, err := resolveHostnameToFirst("example.com")
+		assert.Nil(err)
+		assert.NotNil(validIp)
+	})
+
+	t.Run("test mock resolver returns a valid instance id", func(t *testing.T) {
+		mockClient := &mockedEC2{DescribeNetworkInterfacesOutput: []*ec2.DescribeNetworkInterfacesOutput{&singleResponseDescribeNetworkInterfacesOutput}}
+		testResolver := NewHostnameResolver([]string{examplePrivateIpAddress})
+
+		resp, err := testResolver.ResolveToInstanceId(mockClient)
+		assert.Nil(err)
+		assert.EqualValues(resp, []string{exampleInstanceId})
+	})
+}

--- a/cmd/cmdutil/helpers.go
+++ b/cmd/cmdutil/helpers.go
@@ -61,6 +61,11 @@ func AddInstanceFlag(cmd *cobra.Command) {
 	cmd.Flags().StringSliceP("instance", "i", nil, "Specify what instance IDs you want to target.\nMultiple allowed, delimited by commas (e.g. --instance i-12345,i-23456)")
 }
 
+// AddsHostnameFlags adds --address to command
+func AddHostnameFlag(cmd *cobra.Command) {
+	cmd.Flags().StringSliceP("address", "a", nil, "Specify what Address or FQDN you want to target.\nMultiple allowed, delimited by commas (e.g. --address 10.240.12.6,10.240.12.7)")
+}
+
 // AddAllProfilesFlag adds --all-profiles to command
 func AddAllProfilesFlag(cmd *cobra.Command) {
 	cmd.Flags().Bool("all-profiles", false, "[USE WITH CAUTION] Parse through ~/.aws/config to target all profiles.")

--- a/cmd/cmdutil/helpers.go
+++ b/cmd/cmdutil/helpers.go
@@ -86,6 +86,11 @@ func AddTagFlag(cmd *cobra.Command) {
 	cmd.Flags().StringSliceP("tag", "t", nil, "Adds the specified tag as an additional column to be displayed during the instance selection prompt.")
 }
 
+// AddsAttributeFlag adds the --attribute flag to command.
+func AddAttributeFlag(cmd *cobra.Command) {
+	cmd.Flags().StringSliceP("attribute", "x", nil, "Adds the specified attribute as an additional column to be displayed during the instance selection prompt.")
+}
+
 // AddSessionNameFlag adds --session-name to command
 func AddSessionNameFlag(cmd *cobra.Command, defaultName string) {
 	cmd.Flags().String("session-name", defaultName, "Specify a name for the tmux session created when multiple instances are selected")

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -34,6 +34,7 @@ func addRunFlags(cmd *cobra.Command) {
 
 func addSessionFlags(cmd *cobra.Command) {
 	cmdutil.AddTagFlag(cmd)
+	cmdutil.AddAttributeFlag(cmd)
 	cmdutil.AddSessionNameFlag(cmd, "ssm-session")
 	cmdutil.AddLimitFlag(cmd, 10, "Set a limit for the number of instance results returned per profile/region combination.")
 }

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -160,12 +160,12 @@ func validateSessionFlags(cmd *cobra.Command, instanceList []string, filterList 
 }
 
 // validateRunFlags validates the usage of certain flags required by the run subcommand
-func validateRunFlags(cmd *cobra.Command, instanceList []string, commandList []string, filterList []*ssm.Target) error {
+func validateRunFlags(cmd *cobra.Command, instanceList []string, addressList []string, commandList []string, filterList []*ssm.Target) error {
 	if len(instanceList) > 0 && len(filterList) > 0 {
 		return cmdutil.UsageError(cmd, "The --filter and --instance flags cannot be used simultaneously.")
 	}
 
-	if len(instanceList) == 0 && len(filterList) == 0 {
+	if len(instanceList) == 0 && len(addressList) == 0 && len(filterList) == 0 {
 		return cmdutil.UsageError(cmd, "You must supply target arguments using either the --filter or --instance flags.")
 	}
 

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -20,6 +20,7 @@ func addBaseFlags(cmd *cobra.Command) {
 	cmdutil.AddDryRunFlag(cmd)
 	cmdutil.AddFilterFlag(cmd)
 	cmdutil.AddInstanceFlag(cmd)
+	cmdutil.AddHostnameFlag(cmd)
 	cmdutil.AddProfileFlag(cmd)
 	cmdutil.AddRegionFlag(cmd)
 }

--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -316,6 +316,7 @@ func Test_validateRunFlags(t *testing.T) {
 	cmdutil.AddCommandFlag(cmd)
 	cmdutil.AddFilterFlag(cmd)
 	cmdutil.AddInstanceFlag(cmd)
+	cmdutil.AddHostnameFlag(cmd)
 	cmd.Execute()
 
 	instanceList := make([]string, 51)

--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -323,33 +323,33 @@ func Test_validateRunFlags(t *testing.T) {
 
 	t.Run("try to use --filter and --instance flags", func(t *testing.T) {
 		targetList := make([]*ssm.Target, 2)
-		err := validateRunFlags(cmd, instanceList, []string{"hostname"}, targetList)
+		err := validateRunFlags(cmd, instanceList, nil, []string{"hostname"}, targetList)
 		assert.Error(err)
 	})
 
 	t.Run("specify more than 5 filters", func(t *testing.T) {
 		targetList := make([]*ssm.Target, 6)
-		err := validateRunFlags(cmd, nil, []string{"hostname"}, targetList)
+		err := validateRunFlags(cmd, nil, nil, []string{"hostname"}, targetList)
 		assert.Error(err)
 	})
 
 	t.Run("no instances or filters specified", func(t *testing.T) {
-		err := validateRunFlags(cmd, nil, []string{"hostname"}, nil)
+		err := validateRunFlags(cmd, nil, nil, []string{"hostname"}, nil)
 		assert.Error(err)
 	})
 
 	t.Run(">50 specified instances", func(t *testing.T) {
-		err := validateRunFlags(cmd, instanceList, []string{"hostname"}, nil)
+		err := validateRunFlags(cmd, instanceList, nil, []string{"hostname"}, nil)
 		assert.Error(err)
 	})
 
 	t.Run("no command specified", func(t *testing.T) {
-		err := validateRunFlags(cmd, []string{"myInstance"}, nil, nil)
+		err := validateRunFlags(cmd, []string{"myInstance"}, nil, nil, nil)
 		assert.Error(err)
 	})
 
 	t.Run("valid flag combination", func(t *testing.T) {
-		err := validateRunFlags(cmd, []string{"myInstance"}, []string{"hostname"}, nil)
+		err := validateRunFlags(cmd, []string{"myInstance"}, nil, []string{"hostname"}, nil)
 		assert.NoError(err)
 	})
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -48,6 +48,9 @@ func runCommand(cmd *cobra.Command, args []string) {
 	if instanceList, err = cmdutil.GetFlagStringSlice(cmd, "instance"); err != nil {
 		log.Fatal(err)
 	}
+	if addressList, err = cmdutil.GetFlagStringSlice(cmd, "address"); err != nil {
+		log.Fatal(err)
+	}
 	if commandList, err = getCommandList(cmd); err != nil {
 		log.Fatal(err)
 	}
@@ -55,7 +58,7 @@ func runCommand(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
-	if err := validateRunFlags(cmd, instanceList, commandList, targets); err != nil {
+	if err := validateRunFlags(cmd, instanceList, addressList, commandList, targets); err != nil {
 		log.Fatal(err)
 	}
 

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -44,7 +44,7 @@ func newCommandSSMSession() *cobra.Command {
 
 func startSessionCommand(cmd *cobra.Command, args []string) {
 	var err error
-	var instanceList, addressList, profileList, regionList, tagList []string
+	var instanceList, addressList, profileList, regionList, tagList, attributeList []string
 
 	// Get all of our CLI flag values
 	if err = cmdutil.ValidateArgs(cmd, args); err != nil {
@@ -75,6 +75,9 @@ func startSessionCommand(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 	if tagList, err = cmdutil.GetFlagStringSlice(cmd, "tag"); err != nil {
+		log.Fatal(err)
+	}
+	if attributeList, err = cmdutil.GetFlagStringSlice(cmd, "attribute"); err != nil {
 		log.Fatal(err)
 	}
 
@@ -167,7 +170,7 @@ func startSessionCommand(cmd *cobra.Command, args []string) {
 		}
 	} else {
 		// If -i was not specified, go to a selection prompt before starting sessions
-		selectedInstances, err := startSelectionPrompt(&instancePool, totalInstances, tagList)
+		selectedInstances, err := startSelectionPrompt(&instancePool, totalInstances, tagList, attributeList)
 		if err != nil {
 			if err == terminal.InterruptErr {
 				log.Info("Instance selection interrupted.")
@@ -319,7 +322,7 @@ func addInstanceToTmuxWindow(tmuxWindow *gomux.Window, profile string, region st
 	return tPane.Exec(fmt.Sprintf("aws ssm start-session --profile %s --region %s --target %s", profile, region, instanceID))
 }
 
-func startSelectionPrompt(instances *instance.InstanceInfoSafe, totalInstances int32, tags ssmx.ListSlice) (selectedInstances []instance.InstanceInfo, err error) {
+func startSelectionPrompt(instances *instance.InstanceInfoSafe, totalInstances int32, tags, attributes ssmx.ListSlice) (selectedInstances []instance.InstanceInfo, err error) {
 	instanceIDList := []string{}
 	promptList := instances.FormatStringSlice([]string(tags)...)
 	fmt.Println("      ", promptList[0])

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -110,13 +110,13 @@ func startSessionCommand(cmd *cobra.Command, args []string) {
 		wg.Add(1)
 		go func(sess *session.Session, instancePool *instance.InstanceInfoSafe) {
 			defer wg.Done()
-
-			ssmClient := ssm.New(sess.Session)
-			ec2Client := ec2.New(sess.Session)
 			var threadLocalInstanceList []string
 			copy(threadLocalInstanceList, instanceList)
 
+			ssmClient := ssm.New(sess.Session)
+
 			if len(addressList) > 0 {
+				ec2Client := ec2.New(sess.Session)
 				hr := resolver.NewHostnameResolver(addressList)
 				ids, _ := hr.ResolveToInstanceId(ec2Client)
 				threadLocalInstanceList = append(threadLocalInstanceList, ids...)

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -324,7 +324,8 @@ func addInstanceToTmuxWindow(tmuxWindow *gomux.Window, profile string, region st
 
 func startSelectionPrompt(instances *instance.InstanceInfoSafe, totalInstances int32, tags, attributes ssmx.ListSlice) (selectedInstances []instance.InstanceInfo, err error) {
 	instanceIDList := []string{}
-	promptList := instances.FormatStringSlice([]string(tags)...)
+	fields := append([]string(tags), []string(attributes)...)
+	promptList := instances.FormatStringSlice(fields...)
 	fmt.Println("      ", promptList[0])
 
 	prompt := &survey.MultiSelect{

--- a/cmd/ssm-run/README.md
+++ b/cmd/ssm-run/README.md
@@ -132,6 +132,8 @@ INFO    Execution results: 1 SUCCESS, 0 FAILED
 ### usage flags
 
 ```
+-a, --address strings       
+    Specify what Address or FQDN you want to target. Multiple allowed, delimited by commas (e.g. --address 10.240.12.6,10.240.12.7
 --all-profiles
 	[USE WITH CAUTION] Parse through ~/.aws/config to target all profiles.
 -c, --command string

--- a/cmd/ssm-session/README.md
+++ b/cmd/ssm-session/README.md
@@ -162,4 +162,6 @@ INFO    Retrieved 9 usable instances.
         Specify a name for the tmux session created when multiple instances are selected (default "ssm-session")
     -t, --tag strings
         Adds the specified tag as an additional column to be displayed during the instance selection prompt.
+    --attributes strings
+        Adds the specified attribute as an additional column to be displayed during the instance selection prompt.
 ```

--- a/cmd/ssm-session/README.md
+++ b/cmd/ssm-session/README.md
@@ -128,6 +128,8 @@ INFO    Retrieved 9 usable instances.
 ### usage flags
 
 ```
+    -a, --address strings       
+        Specify what Address or FQDN you want to target. Multiple allowed, delimited by commas (e.g. --address 10.240.12.6,10.240.12.7)
     --all-profiles
         [USE WITH CAUTION] Parse through ~/.aws/config to target all profiles.
     --dry-run

--- a/ec2/helpers.go
+++ b/ec2/helpers.go
@@ -50,3 +50,21 @@ func GetEC2InstanceTags(client ec2iface.EC2API, instances []*string) (ec2Tags ma
 
 	return ec2Tags, nil
 }
+
+// GetEC2InstanceAttributes accepts any number of instance strings and returns a populated InstanceAttributes{} object for each instance
+func GetEC2InstanceAttributes(client ec2iface.EC2API, instances []*string) (ec2Attributes map[string]map[string]string, err error) {
+	instanceInfo, err := getEC2InstanceInfo(client, instances)
+	if err != nil {
+		return nil, fmt.Errorf("Error when trying to retrieve EC2 instance tags\n%v", err)
+	}
+
+	ec2Attributes = make(map[string]map[string]string)
+	for _, i := range instanceInfo {
+		attributeMap := make(map[string]string)
+
+		attributeMap["VpcId"] = *i.VpcId
+		ec2Attributes[*i.InstanceId] = attributeMap
+	}
+
+	return ec2Attributes, nil
+}

--- a/ec2/helpers.go
+++ b/ec2/helpers.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 )
 
-func getEC2InstanceInfo(client ec2iface.EC2API, instances []*string) (output []*ec2.Instance, err error) {
+func GetEC2InstanceInfo(client ec2iface.EC2API, instances []*string) (output []*ec2.Instance, err error) {
 	// Set up our DI input object
 	diInput := &ec2.DescribeInstancesInput{
 		InstanceIds: instances,
@@ -32,7 +32,7 @@ func getEC2InstanceInfo(client ec2iface.EC2API, instances []*string) (output []*
 
 // GetEC2InstanceTags accepts any number of instance strings and returns a populated InstanceTags{} object for each instance
 func GetEC2InstanceTags(client ec2iface.EC2API, instances []*string) (ec2Tags map[string]Tags, err error) {
-	instanceInfo, err := getEC2InstanceInfo(client, instances)
+	instanceInfo, err := GetEC2InstanceInfo(client, instances)
 	if err != nil {
 		return nil, fmt.Errorf("Error when trying to retrieve EC2 instance tags\n%v", err)
 	}
@@ -49,22 +49,4 @@ func GetEC2InstanceTags(client ec2iface.EC2API, instances []*string) (ec2Tags ma
 	}
 
 	return ec2Tags, nil
-}
-
-// GetEC2InstanceAttributes accepts any number of instance strings and returns a populated InstanceAttributes{} object for each instance
-func GetEC2InstanceAttributes(client ec2iface.EC2API, instances []*string) (ec2Attributes map[string]map[string]string, err error) {
-	instanceInfo, err := getEC2InstanceInfo(client, instances)
-	if err != nil {
-		return nil, fmt.Errorf("Error when trying to retrieve EC2 instance tags\n%v", err)
-	}
-
-	ec2Attributes = make(map[string]map[string]string)
-	for _, i := range instanceInfo {
-		attributeMap := make(map[string]string)
-
-		attributeMap["VpcId"] = *i.VpcId
-		ec2Attributes[*i.InstanceId] = attributeMap
-	}
-
-	return ec2Attributes, nil
 }

--- a/ec2/helpers_test.go
+++ b/ec2/helpers_test.go
@@ -34,7 +34,7 @@ func TestGetEC2InstanceInfo(t *testing.T) {
 	mockSvc := &mocks.MockEC2Client{}
 
 	t.Run("get instance info from IDs", func(t *testing.T) {
-		info, err := getEC2InstanceInfo(mockSvc,
+		info, err := GetEC2InstanceInfo(mockSvc,
 			aws.StringSlice([]string{"i-123", "i-456", "i-789"}))
 
 		assert.Lenf(info, 3, "Incorrect number of instances returned, got %d, expected 3", len(info))

--- a/ssm/helpers_test.go
+++ b/ssm/helpers_test.go
@@ -39,12 +39,14 @@ func TestAddInstanceInfo(t *testing.T) {
 		"bar": "2",
 	}
 
+	attributesStruct := make(map[string]string)
+
 	// Initialize our mutex-safe map
 	ip := &instance.InstanceInfoSafe{
 		AllInstances: map[string]instance.InstanceInfo{},
 	}
 
-	addInstanceInfo(aws.String("i-123"), tagStruct, ip, "testprofile", "us-east-1")
+	addInstanceInfo(aws.String("i-123"), tagStruct, attributesStruct, ip, "testprofile", "us-east-1")
 
 	assert.Equalf(
 		ip.AllInstances["i-123"].InstanceID, "i-123",

--- a/ssm/helpers_test.go
+++ b/ssm/helpers_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/disneystreaming/ssm-helpers/ssm/instance"
@@ -33,27 +34,42 @@ func TestCreateSSMDescribeInstanceInput(t *testing.T) {
 func TestAddInstanceInfo(t *testing.T) {
 	assert := assert.New(t)
 
-	// Create our tag data
-	tagStruct := map[string]string{
-		"foo": "1",
-		"bar": "2",
+	id := "i-123"
+	tags := []*ec2.Tag{
+		{
+			Key:   aws.String("foo"),
+			Value: aws.String("1"),
+		},
+		{
+			Key:   aws.String("bar"),
+			Value: aws.String("2"),
+		},
 	}
 
-	attributesStruct := make(map[string]string)
+	cleanedTags := make(map[string]string)
+	for _, tag := range tags {
+		cleanedTags[*tag.Key] = *tag.Value
+	}
+
+	dummyInstance := ec2.Instance{
+		InstanceId: aws.String(id),
+		Tags:       tags,
+		VpcId:      aws.String("vpc-123"),
+	}
 
 	// Initialize our mutex-safe map
 	ip := &instance.InstanceInfoSafe{
 		AllInstances: map[string]instance.InstanceInfo{},
 	}
 
-	addInstanceInfo(aws.String("i-123"), tagStruct, attributesStruct, ip, "testprofile", "us-east-1")
+	addInstanceInfo(aws.String(id), dummyInstance, ip, "testprofile", "us-east-1")
 
 	assert.Equalf(
-		ip.AllInstances["i-123"].InstanceID, "i-123",
-		"Instance info object returned wrong instance ID, got %s, expected 'i-123'",
-		ip.AllInstances["i-123"].InstanceID,
+		ip.AllInstances[id].InstanceID, id,
+		"Instance info object returned wrong instance ID, got %s, expected '%s'",
+		ip.AllInstances[id].InstanceID, id,
 	)
 
-	assert.True(reflect.DeepEqual(ip.AllInstances["i-123"].Tags, tagStruct))
+	assert.True(reflect.DeepEqual(ip.AllInstances[id].Tags, cleanedTags))
 
 }

--- a/ssm/instance/fetch.go
+++ b/ssm/instance/fetch.go
@@ -12,9 +12,7 @@ func GetSessionInstances(client ssmiface.SSMAPI, diiInput *ssm.DescribeInstanceI
 	if err = client.DescribeInstanceInformationPages(
 		diiInput,
 		func(page *ssm.DescribeInstanceInformationOutput, lastPage bool) bool {
-			for _, instance := range page.InstanceInformationList {
-				output = append(output, instance)
-			}
+			output = append(output, page.InstanceInformationList...)
 
 			// If it's not the last page, continue
 			return !lastPage

--- a/ssm/instance/types.go
+++ b/ssm/instance/types.go
@@ -22,6 +22,7 @@ type InstanceInfo struct {
 	Region     string
 	Profile    string
 	Tags       map[string]string
+	Attributes map[string]string
 }
 
 // FormatStringSlice is used to return a strings preformatted to the correct width for selection prompts

--- a/ssm/instance/types.go
+++ b/ssm/instance/types.go
@@ -26,7 +26,7 @@ type InstanceInfo struct {
 }
 
 // FormatStringSlice is used to return a strings preformatted to the correct width for selection prompts
-func (i *InstanceInfoSafe) FormatStringSlice(includeTags ...string) (outSlice []string) {
+func (i *InstanceInfoSafe) FormatStringSlice(includeFields ...string) (outSlice []string) {
 	stringBuffer := new(bytes.Buffer)
 
 	// Set up our tabwriter to nicely space our output
@@ -34,13 +34,13 @@ func (i *InstanceInfoSafe) FormatStringSlice(includeTags ...string) (outSlice []
 
 	// Set up our header string
 	headerString := "Instance ID\tRegion\tProfile\t"
-	for _, tagName := range includeTags {
-		headerString = fmt.Sprintf("%s%s\t", headerString, tagName)
+	for _, fieldName := range includeFields {
+		headerString = fmt.Sprintf("%s%s\t", headerString, fieldName)
 	}
 	fmt.Fprintf(tw, "%s\n", headerString)
 
 	for _, v := range i.AllInstances {
-		fmt.Fprintf(tw, "%v\n", v.FormatString(includeTags...))
+		fmt.Fprintf(tw, "%v\n", v.FormatString(includeFields...))
 	}
 
 	tw.Flush()
@@ -49,12 +49,19 @@ func (i *InstanceInfoSafe) FormatStringSlice(includeTags ...string) (outSlice []
 }
 
 // FormatString returns a string with various information about a given instance
-func (i *InstanceInfo) FormatString(includeTags ...string) string {
+func (i *InstanceInfo) FormatString(includeFields ...string) string {
 	// Formatted string will always contain at least base info
 	formattedString := fmt.Sprintf("%s\t%s\t%s\t", i.InstanceID, i.Region, i.Profile)
+	fields := i.Tags
 
-	for _, v := range includeTags {
-		formattedString = fmt.Sprintf("%s%s\t", formattedString, i.Tags[v])
+	for k, v := range i.Attributes {
+		if _, prs := fields[k]; !prs {
+			fields[k] = v
+		}
+	}
+
+	for _, v := range includeFields {
+		formattedString = fmt.Sprintf("%s%s\t", formattedString, fields[v])
 	}
 
 	return formattedString

--- a/ssm/instance/types.go
+++ b/ssm/instance/types.go
@@ -52,10 +52,8 @@ func (i *InstanceInfo) FormatString(includeTags ...string) string {
 	// Formatted string will always contain at least base info
 	formattedString := fmt.Sprintf("%s\t%s\t%s\t", i.InstanceID, i.Region, i.Profile)
 
-	if includeTags != nil {
-		for _, v := range includeTags {
-			formattedString = fmt.Sprintf("%s%s\t", formattedString, i.Tags[v])
-		}
+	for _, v := range includeTags {
+		formattedString = fmt.Sprintf("%s%s\t", formattedString, i.Tags[v])
 	}
 
 	return formattedString

--- a/ssm/instance/types.go
+++ b/ssm/instance/types.go
@@ -21,8 +21,8 @@ type InstanceInfo struct {
 	InstanceID string
 	Region     string
 	Profile    string
+	VpcId      string
 	Tags       map[string]string
-	Attributes map[string]string
 }
 
 // FormatStringSlice is used to return a strings preformatted to the correct width for selection prompts
@@ -53,12 +53,7 @@ func (i *InstanceInfo) FormatString(includeFields ...string) string {
 	// Formatted string will always contain at least base info
 	formattedString := fmt.Sprintf("%s\t%s\t%s\t", i.InstanceID, i.Region, i.Profile)
 	fields := i.Tags
-
-	for k, v := range i.Attributes {
-		if _, prs := fields[k]; !prs {
-			fields[k] = v
-		}
-	}
+	fields["VpcId"] = i.VpcId
 
 	for _, v := range includeFields {
 		formattedString = fmt.Sprintf("%s%s\t", formattedString, fields[v])


### PR DESCRIPTION
# General
This PR adds the capability to lookup an instance ID via the private address of an attached NIC.

Functionally this would be similar to the following bash one-liner

```bash
ssm session -i $(aws ec2 describe-network-interfaces --filters Name=addresses.private-ip-address,Values=<SOME PRIVATE IP> --query 'NetworkInterfaces[0].Attachment.InstanceId' | tr -d '"')
```

However this allows the added convenience of checking across multiple accounts, regions and handling the IP resolution.

## Example commands
### Session

```bash
ssm session -a 10.0.10.0
```


```bash
ssm session -a 10.0.10.0,10.0.10.1
```

```bash
ssm session -a some.internal.dns.record.example.com
```

### Run
```
bash
ssm session -a 10.0.10.0 -c 'uname -a'
```

# Changes
- Adds a new flag `--address`/`-a`
- Adds a new Resolver interface
- Adds an `--attribute` flag for additional formatting data
  - `VpcId`

# TODO
- [x] Documentation