### PR TITLE
Implement `docker.binaries` deprecation mitigation

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -48,7 +48,7 @@ brews:
     bin.install_symlink  bin/"ssm" => "ssm-helpers"
 
 dockers:
-  - binaries:
+  - ids:
     - ssm
     goos: linux
     dockerfile: Dockerfile


### PR DESCRIPTION
# General

Per https://goreleaser.com/deprecations/#dockerbinaries, release `v0.175.0` removed the `docker.binaries` field. This PR implements the migration from `docker.binaries` -> `docker.ids`.

## Tests

```
   • loading config file       file=.goreleaser.yml
   • checking config: 
      • snapshotting     
      • github/gitlab/gitea releases
      • project name     
      • loading go mod information
      • building binaries
      • creating source archive
      • archives         
      • linux packages   
      • snapcraft packages
      • calculating checksums
      • signing artifacts
      • signing docker images
      • docker images    
      • docker manifests 
      • artifactory      
      • blobs            
      • homebrew tap formula
      • scoop manifests  
      • discord          
      • reddit           
      • slack            
      • teams            
      • twitter          
      • milestones       
   • config is valid
```