### PR TITLE
Add config check step to goreleaser

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -20,3 +20,9 @@ jobs:
 
       - name: Testing (gotest)
         run: make test
+
+      - name: GoReleaser Config Check
+        uses: goreleaser/goreleaser-action@v1
+        with:
+          version: latest
+          args: check -q


### PR DESCRIPTION
# General
This PR adds a check step for validating our `.goreleaser.yml`. This was added due to breaking changes being introduced to goreleaser, causing issues in our last two release cuts. A better fix would be to probably pin the version, but this check should atleast both, catch any issues with changes to the file and catch any breaking changes introduced by the tool upstream.