### PR TITLE
Add support for MFA, related to issue #58

### DIFF
--- a/aws/session/session.go
+++ b/aws/session/session.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	log "github.com/sirupsen/logrus"
 
@@ -48,9 +49,10 @@ func stsCredentialsSet() bool {
 
 func newSession(profile string, region string, logger *log.Logger) *Session {
 	options := session.Options{
-		Config:            *config.NewDefaultConfig(region),
-		Profile:           profile,
-		SharedConfigState: session.SharedConfigEnable,
+		Config:                  *config.NewDefaultConfig(region),
+		Profile:                 profile,
+		SharedConfigState:       session.SharedConfigEnable,
+		AssumeRoleTokenProvider: stscreds.StdinTokenProvider,
 	}
 
 	session, err := session.NewSessionWithOptions(options)


### PR DESCRIPTION
Fixes #58

When running the previous release:
```
$ ssm session --region us-east-1 --profile <REDACTED> --instance <REDACTED>
FATAL   Error when trying to create session:
AssumeRoleTokenProviderNotSetError: assume role with MFA enabled, but AssumeRoleTokenProvider session option not set.
```

When running with this PR:
```
$ ./ssm session --region us-east-1 --profile <REDACTED> --instance <REDACTED>
Assume Role MFA token code: <REDACTED>
INFO    Retrieved 10 usable instances.
       Instance ID          Region     Profile
? Showing 10/820 instances. Make a Selection:  [Use arrows to move, space to select, type to filter]
```