### PR TITLE
Fixes a bug in the instance id list copy

### DIFF
--- a/cmd/session.go
+++ b/cmd/session.go
@@ -114,7 +114,7 @@ func startSessionCommand(cmd *cobra.Command, args []string) {
 		go func(sess *session.Session, instancePool *instance.InstanceInfoSafe) {
 			defer wg.Done()
 			var threadLocalInstanceList []string
-			copy(threadLocalInstanceList, instanceList)
+			threadLocalInstanceList = append(threadLocalInstanceList, instanceList...)
 
 			ssmClient := ssm.New(sess.Session)
 


### PR DESCRIPTION
# General
This PR fixes a bug reported directly by @ledor473 that caused sessions to fail to look up instances by id using the -i flag. This was caused by a bad use of `copy` causing 0 instances to be copied from the array of user passed instance ids to an empty thread local slice.

```
./bin/ssm session -i <redacted> --profile <redacted> --region us-east-1
INFO    Retrieved 1 usable instances.

sh-4.2$
```