### PR TITLE
Add tmux as a homebrew dependency

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -41,6 +41,7 @@ brews:
   description: "Help manage systems with AWS Systems Manager with management helpers."
   folder: Formula
   dependencies:
+    - tmux
     - awscli
     - disneystreaming/tap/aws-session-manager-plugin
   install: |


### PR DESCRIPTION
This adds `tmux` as an additional dependency in our homebrew formula as this is currently treated as a runtime dependency.

relates to #61