### PR TITLE
Fix unaligned output from GetEc2InstanceInfo

### DIFF
--- a/ssm/helpers.go
+++ b/ssm/helpers.go
@@ -199,17 +199,12 @@ func CheckInstanceReadiness(session *session.Session, client ssmiface.SSMAPI, in
 		session.Logger.Error(err)
 	}
 
-	keyedInstances := make(map[string]ec2.Instance)
-	for _, i := range instanceInfo {
-		keyedInstances[*i.InstanceId] = *i
-	}
-
 	if limit > len(readyInstances) {
 		limit = len(readyInstances)
 	}
 
-	for _, i := range readyInstances[:limit] {
+	for idx, i := range readyInstances[:limit] {
 		// Append our instance info to the master list
-		addInstanceInfo(i, keyedInstances[*i], readyInstancePool, session.ProfileName, *session.Session.Config.Region)
+		addInstanceInfo(i, *instanceInfo[idx], readyInstancePool, session.ProfileName, *session.Session.Config.Region)
 	}
 }

--- a/ssm/helpers.go
+++ b/ssm/helpers.go
@@ -199,12 +199,17 @@ func CheckInstanceReadiness(session *session.Session, client ssmiface.SSMAPI, in
 		session.Logger.Error(err)
 	}
 
+	keyedInstances := make(map[string]ec2.Instance)
+	for _, i := range instanceInfo {
+		keyedInstances[*i.InstanceId] = *i
+	}
+
 	if limit > len(readyInstances) {
 		limit = len(readyInstances)
 	}
 
-	for idx, i := range readyInstances[:limit] {
+	for _, i := range readyInstances[:limit] {
 		// Append our instance info to the master list
-		addInstanceInfo(i, *instanceInfo[idx], readyInstancePool, session.ProfileName, *session.Session.Config.Region)
+		addInstanceInfo(i, keyedInstances[*i], readyInstancePool, session.ProfileName, *session.Session.Config.Region)
 	}
 }


### PR DESCRIPTION
# General
This PR addresses an issue in the `CheckInstanceReadiness` function where the list of instances returned from GetEC2InstanceInfo is assumed to be aligned to the index of the instance ids passed in. This PR updates the GetEC2InstanceInfo method to conform to this assumption, aligning the output to the input.

## Linked Issues
resolves #67 
